### PR TITLE
Add support for MaterializeCSS material box

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,6 +28,11 @@
             }).addClass('externalLink');
         });
 
+        // initialize images
+        $(document).ready(function(){
+          $('.materialboxed').materialbox();
+        });
+
       });
 
     </script>

--- a/_sass/_my_styles.scss
+++ b/_sass/_my_styles.scss
@@ -104,3 +104,9 @@ article.project {
     background-position: center center;
   }
 }
+
+
+// Materialbox for Images (make images in columns work correctly)
+.materialboxed.initialized.active {
+  max-width: unset;
+}


### PR DESCRIPTION
The MaterializeCSS library comes with support for rendering images as thumbnails
that expand to full-screen on click. It requires running an initialization code
on our default layout page, which has been added here.

In addition, we add a style for .materialboxed.initialized.active that allow
the material box to become full screen even when the image is part of a column.

Read more about material box: [MaterializeCSS Material Box](http://materializecss.com/media.html)