### PR TITLE
Add alt attribute to post featured images

### DIFF
--- a/_sass/_my_styles.scss
+++ b/_sass/_my_styles.scss
@@ -64,7 +64,14 @@ div.card.project_preview {
 
   // darken the background image
   .card-image { background-color: black; }
-  .card-image img { opacity: 0.9; }
+  .card-image img {
+    opacity: 0.9;
+
+    // ensure the alt tag is readable if image loading fails
+    min-height: 150px;
+    text-align: right;
+    color: white;
+  }
 
   // improve readability of title
   .card-title {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: "Finn Woelm"
         <a class="no_underline" href="{{ post.url | prepend: site.baseurl }}">
           <div class="card post_preview">
             <div class="card-image">
-              <img src="{{ post.date | date: "%Y-%m-%d" | prepend: '/images/' | prepend: site.baseurl | append: '-' | append: post.slug | append: '.jpg'}}">
+              <img src="{{ post.date | date: "%Y-%m-%d" | prepend: '/images/' | prepend: site.baseurl | append: '-' | append: post.slug | append: '.jpg'}}" alt="Featured Image for {{ post.title }}" >
               <span class="card-title">{{ post.title }}</span>
               <div class="card-date">{{ post.date | date: "%b %-d, %Y" }}</div>
               <div class="card-category {{ post.categories.first }}">


### PR DESCRIPTION
Added code to automatically generate alt tags for featured images of posts.
Post featured images are the only images used so far.

Specified css styles min-height, color, and text-align for the image tag on
post previews, so that the text is actually legible.