### PR TITLE
Fix link to RSS feed in "Hello, World"

### DIFF
--- a/_posts/2016-06-18-hello-world.md
+++ b/_posts/2016-06-18-hello-world.md
@@ -32,5 +32,5 @@ post goes live.
 Have an absolutely splendid day :)
 
 [seahorse-video]: https://www.youtube.com/watch?v=KKvFVB29yS0
-[rss-feed]: http://localhost:4000/feed.xml
+[rss-feed]: {{ '/feed.xml' | prepend: site.baseurl }}
 [twitter]: https://twitter.com/FinnWoelm


### PR DESCRIPTION
The link to the RSS feed was specified as an absolute url to localhost:4000.
This was changed to be relative to the current site.baseurl.